### PR TITLE
fix: workflow chain broken — qc silent, release hardcoded, docs over-…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -213,19 +213,12 @@ jobs:
             -rewriteAll \
             -webVowl
 
-          # Default entry point (English)
           cp "./_site/${VERSION}/doc/index-en.html" "./_site/${VERSION}/doc/index.html" || true
 
-      # ── Note: serializations are served by Widoco automatically ─────────────
-      # Widoco copies the source ontology file and generates download buttons
-      # for JSON-LD, RDF/XML, N-Triples, and TTL in the HTML documentation.
-      # The files are placed at the root of the doc/ output as ontology.jsonld,
-      # ontology.rdf, ontology.ntx, ontology.ttl — no manual copy needed.
-
       # ── Update /dev/ ──────────────────────────────────────────────────────
-      # /dev/ always mirrors the latest build from main (every push).
-      # Named releases (e.g. /2025-11-20/ or /1.0.0/) are preserved alongside.
-      # This gives a stable URL for development/preview access.
+      # Always mirrors the latest build. On a qc build (no version payload)
+      # this is the only thing published — no versioned directory, no index
+      # update — keeping release history clean.
       # ──────────────────────────────────────────────────────────────────────
       - name: Update /dev/
         run: |
@@ -233,12 +226,12 @@ jobs:
           rm -rf ./_site/dev
           cp -r "./_site/${VERSION}" ./_site/dev
 
-      # ── Build root index.html ─────────────────────────────────────────────
-      # Generates a simple version listing page as the site root.
-      # Reads existing version directories from the previously fetched
-      # gh-pages branch and adds the current version to the list.
+      # ── Build root index.html (release only) ─────────────────────────────
+      # Only regenerated when a real version is provided (release trigger).
+      # qc builds only update /dev/ and skip this step.
       # ──────────────────────────────────────────────────────────────────────
       - name: Build root index.html
+        if: needs.check.outputs.version != 'latest'
         run: |
           VERSION="${{ needs.check.outputs.version }}"
 
@@ -323,6 +316,12 @@ jobs:
       #   rm -rf <version>/
       #   git commit -am "Remove version <version>" && git push
       # ──────────────────────────────────────────────────────────────────────
+      # On qc builds (version = "latest") remove the _site/latest/ build dir —
+      # /dev/ already has the content; we don't want a permanent /latest/ page.
+      - name: Drop build dir for dev deploys
+        if: needs.check.outputs.version == 'latest'
+        run: rm -rf ./_site/latest
+
       - name: Deploy to gh-pages branch
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -57,17 +57,17 @@ on:
   # Bot commits from this workflow touch only release artifacts (*.owl, *.ttl,
   # *.json) which are NOT in the paths list below, so there is no infinite loop.
   push:
-    branches: ["main"]
+    branches: [main]
     paths:
-      - 'src/ontology/*-edit.owl'
-      - 'src/ontology/components/**'
-      - 'src/ontology/imports/**'
-      - 'src/ontology/Makefile'
-      - 'src/ontology/*-Makefile'
+      - src/ontology/*-edit.owl
+      - src/ontology/components/**
+      - src/ontology/imports/**
+      - src/ontology/Makefile
+      - src/ontology/*-Makefile
 
   # ── Pull request: fast PR checks (no path filter — runs on every PR) ────────
   pull_request:
-    branches: ["main"]
+    branches: [main]
 
   # ── Manual trigger ──────────────────────────────────────────────────────────
   workflow_dispatch:
@@ -317,20 +317,29 @@ jobs:
       # ──────────────────────────────────────────────────────────────────────
       - name: Build ontology (refresh imports + generate all release assets)
         env:
-          ROBOT_ENV: 'ROBOT_JAVA_ARGS=-Xmx6G'
+          ROBOT_ENV: ROBOT_JAVA_ARGS=-Xmx6G
         run: |
           cd src/ontology
           make refresh-imports all_assets
 
       # ── Commit release artifacts ───────────────────────────────────────────
+      # git add each glob separately so a missing pattern (e.g. no *.json) does
+      # not abort the entire staging step.
+      - name: Stage release artifacts
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git add src/ontology/*.owl       || true
+          git add src/ontology/*.ttl       || true
+          git add src/ontology/*.json      || true
+          git add src/ontology/imports/*.owl || true
+
       - name: Commit ontology release assets
-        uses: EndBug/add-and-commit@v9
-        with:
-          message: "Building the ontology from the edits"
-          cwd: "."
-          add: "src/ontology/*.owl src/ontology/*.json src/ontology/*.ttl src/ontology/imports/*.owl --force"
-          default_author: github_actions
-          push: true
+        run: |
+          git diff --cached --quiet && echo "Nothing to commit." && exit 0
+          git commit -m "Building the ontology from the edits"
+          git push
 
       # ── Trigger documentation workflow ─────────────────────────────────────
       - name: Trigger Documentation Workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,9 +95,12 @@ jobs:
       - name: Stamp version into artifacts
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          ONTBASE="https://w3id.org/pmd/log"
-          for f in src/ontology/log-full.owl src/ontology/log-base.owl src/ontology/log-simple.owl src/ontology/log.owl; do
-            [ -f "$f" ] || continue
+          ODK_YAML=$(find src/ontology -maxdepth 1 -name "*-odk.yaml" | head -1)
+          ONT_ID=$(python3 -c "import yaml; d=yaml.safe_load(open('$ODK_YAML')); print(d['id'])")
+          URIBASE=$(python3 -c "import yaml; d=yaml.safe_load(open('$ODK_YAML')); print(d['uribase'])")
+          ONTBASE="${URIBASE}/${ONT_ID}"
+          for f in $(find src/ontology -maxdepth 1 -name "*.owl" \
+                     ! -name "*-edit.owl" ! -name "*-idranges.owl"); do
             robot annotate \
               --input "$f" \
               --version-iri "${ONTBASE}/${VERSION}" \
@@ -117,7 +120,7 @@ jobs:
         with:
           message: Release v${{ steps.version.outputs.version }}
           cwd: .
-          add: src/ontology/*.owl src/ontology/*.ttl --force
+          add: src/ontology/*.owl src/ontology/*.ttl
           default_author: github_actions
           push: true
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,16 +32,6 @@ src/ontology/mirror
 src/ontology/mirror/*
 src/ontology/reports/*
 !src/ontology/reports/release-diff.md
-src/ontology/log.owl
-src/ontology/log.obo
-src/ontology/log.json
-src/ontology/log.db
-src/ontology/log-base.*
-src/ontology/log-basic.*
-src/ontology/log-full.*
-src/ontology/log-simple.*
-src/ontology/log-simple-non-classified.*
-
 src/ontology/seed.txt
 src/ontology/dosdp-tools.log
 src/ontology/ed_definitions_merged.owl


### PR DESCRIPTION
## Summary

Three bugs discovered and verified in production on a downstream fork
(materialdigital/logistics-application-ontology). All three cause silent
failures — no error, just wrong behavior.

---

### Bug 1 — qc.yml: build artifacts never committed (silent failure)

**Root cause (two compounding issues):**

1. `.gitignore` contains `src/ontology/log-base.*`, `src/ontology/log-full.*`
   etc. — ODK default that assumes built artifacts are not tracked. But the
   workflow design *requires* them committed so `release.yml` and `docs.yml`
   can find them on the next run.

2. The EndBug commit step uses a single `git add` call with all globs in one
   string. When `src/ontology/*.json` matches nothing (ODK does not produce
   JSON for all ontologies), git exits with `fatal: pathspec did not match any
   files` — aborting the entire staging command. Nothing is staged, so
   EndBug reports "Working tree clean. Nothing to commit." and succeeds — with
   zero files committed.

**Effect:** Every build silently discards its output. `src/ontology/log-full.owl`
stays permanently stale. `release.yml` stamps an outdated artifact.
`docs.yml` documents the wrong ontology state.

**Fix:**
- Remove `src/ontology/log-base.*` / `log-full.*` / `log-simple.*` / `log.owl`
  / `log.obo` / `log.json` / `log.db` from `.gitignore` — built artifacts must
  be tracked.
- Replace single EndBug `git add` call with per-glob `git add || true` so one
  missing pattern cannot abort the rest.

---

### Bug 2 — release.yml: hardcoded ontology ID and base IRI

The stamp step hardcodes:

```yaml
ONTBASE="https://w3id.org/pmd/log"
for f in src/ontology/log-full.owl src/ontology/log-base.owl ...

Any repo seeded with a different ontology ID will silently find no files to
stamp and produce a release with wrong or missing `owl:versionIRI`.

**Fix:** Read `id` and `uribase` from the ODK yaml at runtime using Python
(available in the ODK container). Discover artifact files with `find` instead
of hardcoded names — same pattern already used in `docs.yml`.

---

### Bug 3 — docs.yml: full Widoco build triggered on every push to main

`qc.yml` dispatches `trigger-docs` with no version payload after every build.
`docs.yml` runs a full Widoco build each time, publishing to gh-pages on every
commit. This wastes CI minutes and pollutes gh-pages with a `/latest/` directory
that duplicates `/dev/` and unnecessarily rebuilds the release index.

**Fix:** Branch on whether a version payload is present:
- **No version (qc trigger):** build Widoco → update `/dev/` only, skip versioned directory, skip index rebuild
- **Version present (release trigger):** build Widoco → create `/1.0.0/`, update `/dev/`, rebuild index

Release history on gh-pages is never touched by dev builds.

---

## Files changed

| File | Change |
|------|--------|
| `.gitignore` | Remove `src/ontology/log-*.owl/ttl/obo/json/db` ignore entries |
| `.github/workflows/qc.yml` | Fix commit step: per-glob `git add \|\| true` |
| `.github/workflows/release.yml` | Dynamic `ONTBASE` + `find` for artifacts via Python |
| `.github/workflows/docs.yml` | Skip versioned dir + index rebuild on dev builds |

## Verified

All fixes tested end-to-end on materialdigital/logistics-application-ontology main branch.
The qc build now correctly commits all built artifacts after each successful build.
